### PR TITLE
Fix /wiki redirect

### DIFF
--- a/app.py
+++ b/app.py
@@ -26,7 +26,7 @@ WIKI_REDIRECTS = {
     "usbhook": "Inspecting_the_initramfs",
     "warning-repo": "Troubleshooting#Installed_version_newer_than_the_version_in_the_repositories",
     "warning-repo2": "Troubleshooting#Newer_version_in_binary_package_repositories_than_in_aports_folder",
-    "wiki": "Main_page",
+    "wiki": "Main_Page",
 }
 
 


### PR DESCRIPTION
Before: https://postmarketos.org/wiki redirects to
https://wiki.postmarketos.org/wiki/Main_page which is an empty page
After: https://postmarketos.org/wiki redirects to
https://wiki.postmarketos.org/wiki/Main_Page which is the main page