### PR TITLE
Change Riot link for a matrix.to link

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -36,7 +36,7 @@
             <li class="dib pa3"><a href="https://github.com/postmarketOS">GitHub</a></li>
             <li class="dib pa3"><a href="https://reddit.com/r/postmarketOS">/r/postmarketOS</a></li>
             <li class="dib pa3"><a href="https://twitter.com/postmarketOS">@postmarketOS</a></li>
-            <li class="dib pa3"><a href="https://chat.disroot.org/#/room/#postmarketos:disroot.org">#postmarketos:disroot.org</a></li>
+            <li class="dib pa3"><a href="https://matrix.to/#/#postmarketos:disroot.org">#postmarketos:disroot.org</a></li>
             <li class="dib pa3">#postmarketos on Freenode IRC</li>
             </ul>
         </div>


### PR DESCRIPTION
Stop forcing people to Riot you fools ;)

matrix.to is the official way to link people to Matrix chat rooms.