### PR TITLE
Fix typo on home page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -79,7 +79,7 @@
     </p>
     <p>
         We are <b>well aware</b> of the situation and
-        <b><a href="https://wiki.postmarketos.org/wiki/Firmware">exploring our options</a></b>. One a side note,
+        <b><a href="https://wiki.postmarketos.org/wiki/Firmware">exploring our options</a></b>. On a side note,
         we are also interested in using the
         <b><a href="https://wiki.postmarketos.org/wiki/The_Mainline_Kernel">mainline kernel</a></b>
         (instead of some outdated Android fork), so we can at least have a safer userspace.


### PR DESCRIPTION
Replacing

```
One a side note,...
```

with

```
On a side note,...
```