### PR TITLE
Privacy policy

### DIFF
--- a/content/page/privacy-policy.md
+++ b/content/page/privacy-policy.md
@@ -1,0 +1,6 @@
+title: Privacy Policy
+---
+
+We do not process personal data on this site. We do not use cookies.
+
+If this policy changes, the changes will be published here.

--- a/templates/base.html
+++ b/templates/base.html
@@ -39,6 +39,7 @@
             <li class="dib pa3"><a href="https://matrix.to/#/#postmarketos:disroot.org">#postmarketos:disroot.org</a></li>
             <li class="dib pa3">#postmarketos on Freenode IRC</li>
             </ul>
+            <a href="{{ url_for('static_page', page='privacy-policy') }}" class="center">Privacy policy</a>
         </div>
     </footer>
     {% endblock %}


### PR DESCRIPTION
This PR adds a privacy policy to the website with a link in the footer so the site is GDPR compliant.

Added link to footer on every page:
![screenshot from 2018-05-25 20-32-49](https://user-images.githubusercontent.com/6928199/40555678-2e8cbdb6-604a-11e8-9cab-09d4f10f158f.png)

Added page:
![screenshot from 2018-05-25 20-34-16](https://user-images.githubusercontent.com/6928199/40555714-48be96d2-604a-11e8-9c0a-604299f163e1.png)

The privacy policy itself is borrowed from the https://alpinelinux.org/privacy-policy.html (since they had someone look at it yesterday in their matrix channel)